### PR TITLE
Fix: version conflict message

### DIFF
--- a/internal/executions/process_step.go
+++ b/internal/executions/process_step.go
@@ -10,7 +10,6 @@ import (
 	"github.com/v1Flows/runner/pkg/executions"
 	"github.com/v1Flows/runner/pkg/platform"
 	"github.com/v1Flows/runner/pkg/plugins"
-	"github.com/v1Flows/shared-library/pkg/models"
 	shared_models "github.com/v1Flows/shared-library/pkg/models"
 
 	log "github.com/sirupsen/logrus"
@@ -86,12 +85,12 @@ func processStep(cfg *config.Config, workspace string, actions []shared_models.A
 
 	if danger {
 		// modify the pickup step
-		err = executions.UpdateStep(nil, execution.ID.String(), models.ExecutionSteps{
-			ID: steps[0].ID,
-			Messages: []models.Message{
+		err = executions.UpdateStep(nil, execution.ID.String(), shared_models.ExecutionSteps{
+			ID: step.ID,
+			Messages: []shared_models.Message{
 				{
 					Title: "Caution",
-					Lines: []models.Line{
+					Lines: []shared_models.Line{
 						{
 							Content:   "Plugin version is higher than action version. This may cause issues but execution will still be processed.",
 							Timestamp: time.Now(),


### PR DESCRIPTION
This pull request refactors the usage of the `models` package in `internal/executions/process_step.go` to ensure consistency and clarity by using an alias (`shared_models`) for imports and updating references throughout the file.

### Refactoring for consistency:

* [`internal/executions/process_step.go`](diffhunk://#diff-78ea5be798485e5b60fd1f0de287c203010e5ebcc6e90afb1839c6c52ac620c1L13): Replaced the direct import of `models` with an aliased import (`shared_models`) to improve clarity and avoid conflicts.
* [`internal/executions/process_step.go`](diffhunk://#diff-78ea5be798485e5b60fd1f0de287c203010e5ebcc6e90afb1839c6c52ac620c1L89-R93): Updated all references to `models` in the `processStep` function to use the `shared_models` alias, ensuring consistency across the codebase. This includes changes to `ExecutionSteps`, `Message`, and `Line` types.