### PR TITLE
chore: bump version to 1.2.4

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	log        = logrus.New()
-	version    = "1.2.3"
+	version    = "1.2.4"
 	configFile = kingpin.Flag("config", "Path to configuration file").Short('c').String()
 )
 


### PR DESCRIPTION
This pull request includes a minor version update for the `cmd/runner/main.go` file. The `version` variable has been incremented from `1.2.3` to `1.2.4`.