### PR TITLE
Release v1.2.4

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	log        = logrus.New()
-	version    = "1.2.3"
+	version    = "1.2.4"
 	configFile = kingpin.Flag("config", "Path to configuration file").Short('c').String()
 )
 


### PR DESCRIPTION
This pull request includes updates to versioning and plugin management logic. The most notable changes are the version bump in the `cmd/runner/main.go` file and the addition of logic to handle "latest" plugin versions in the `pkg/plugins/download.go` file.

### Versioning Update:
* [`cmd/runner/main.go`](diffhunk://#diff-a00bb025bf1923f717ec616d0fd151f6a1ee536725aa46cb4af908be57f4d056L26-R26): Updated the `version` variable from `1.2.3` to `1.2.4`.

### Plugin Management Enhancements:
* [`pkg/plugins/download.go`](diffhunk://#diff-8df17c2ebca1c6d92a69745e5ec0a085f98803c87a5a7faafc446f17039dd826R34-R46): Added logic to delete existing plugins when the version is set to "latest," ensuring the latest version is downloaded. This includes removing the existing plugin directory and logging the removal.