### PR TITLE
Release v1.3.1

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	log        = logrus.New()
-	version    = "1.3.0"
+	version    = "1.3.1"
 	configFile = kingpin.Flag("config", "Path to configuration file").Short('c').String()
 )
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	log        = logrus.New()
-	version    = "1.2.4"
+	version    = "1.3.0"
 	configFile = kingpin.Flag("config", "Path to configuration file").Short('c').String()
 )
 

--- a/internal/executions/process_step.go
+++ b/internal/executions/process_step.go
@@ -189,7 +189,11 @@ func processStep(cfg *config.Config, workspace string, actions []shared_models.A
 			}
 
 			if !pass {
-				step.Status = "canceled"
+				if step.Action.Condition.CancelExecution {
+					step.Status = "canceled"
+				} else {
+					step.Status = "skipped"
+				}
 				step.FinishedAt = time.Now()
 
 				if err := executions.UpdateStep(nil, execution.ID.String(), step, targetPlatform); err != nil {

--- a/pkg/plugins/init.go
+++ b/pkg/plugins/init.go
@@ -74,6 +74,12 @@ func Init(cfg *config.Config) (loadedPlugin map[string]Plugin, plugins []shared_
 		{Name: "interaction", Version: "latest"},
 		{Name: "ping", Version: "latest"},
 		{Name: "port_checker", Version: "latest"},
+		{Name: "debug", Version: "latest"},
+		{Name: "git", Version: "latest"},
+		{Name: "ansible", Version: "latest"},
+		{Name: "ssh", Version: "latest"},
+		{Name: "terraform", Version: "latest"},
+		{Name: "mail", Version: "latest"},
 	}
 
 	// Merge mandatory plugins with config plugins, handling conflicts

--- a/pkg/plugins/init.go
+++ b/pkg/plugins/init.go
@@ -74,7 +74,6 @@ func Init(cfg *config.Config) (loadedPlugin map[string]Plugin, plugins []shared_
 		{Name: "interaction", Version: "latest"},
 		{Name: "ping", Version: "latest"},
 		{Name: "port_checker", Version: "latest"},
-		{Name: "step_analysis", Version: "latest"},
 	}
 
 	// Merge mandatory plugins with config plugins, handling conflicts


### PR DESCRIPTION
This pull request includes updates to versioning, execution step handling, and plugin initialization. The most significant changes involve adding new plugins to the initialization process, refining step status handling based on conditions, and incrementing the application version.

### Versioning Update:

* [`cmd/runner/main.go`](diffhunk://#diff-a00bb025bf1923f717ec616d0fd151f6a1ee536725aa46cb4af908be57f4d056L26-R26): Incremented the application version from `1.3.0` to `1.3.1`.

### Execution Step Handling:

* [`internal/executions/process_step.go`](diffhunk://#diff-78ea5be798485e5b60fd1f0de287c203010e5ebcc6e90afb1839c6c52ac620c1R192-R196): Enhanced the `processStep` function to set the step status to "canceled" or "skipped" based on the `CancelExecution` condition in the step action. This ensures more accurate status reporting during execution.

### Plugin Initialization:

* [`pkg/plugins/init.go`](diffhunk://#diff-c5d9e18b3fdeac5f10e03955ea8eab1088f6b2cc9803a28bd25d0b962a2ca676R77-R82): Added six new plugins (`debug`, `git`, `ansible`, `ssh`, `terraform`, `mail`) to the mandatory plugin list, expanding the functionality available during initialization.