### PR TITLE
Fix: change execution end method from EndWithRecovered to EndWithError

### DIFF
--- a/internal/executions/start_processing.go
+++ b/internal/executions/start_processing.go
@@ -205,7 +205,7 @@ func startProcessing(platform string, actions []shared_models.Action, loadedPlug
 					}
 
 					// end execution
-					executions.EndWithRecovered(nil, execution, platform)
+					executions.EndWithError(nil, execution, platform)
 					// Stop heartbeats and finish processing
 					close(doneHeartbeat)
 					finishProcessing(platform, cfg, execution)


### PR DESCRIPTION
This pull request updates the execution error handling logic in the `startProcessing` function to improve clarity and accuracy when ending executions.

Error handling improvement:

* Changed the function call from `executions.EndWithRecovered` to `executions.EndWithError` to more accurately reflect that the execution is ending due to an error, not a recovered panic. (`internal/executions/start_processing.go`)